### PR TITLE
Typing fixes

### DIFF
--- a/src/BarcodeDetectorZXing.ts
+++ b/src/BarcodeDetectorZXing.ts
@@ -68,8 +68,6 @@ export default class BarcodeDetectorZXing {
   }
 
   wrapResult(result:ZXing.Result):DetectedBarcode{
-    const cornerPoints = [];
-
     let minX: number, minY: number, maxX: number, maxY: number;
     
     //set initial values
@@ -95,10 +93,7 @@ export default class BarcodeDetectorZXing {
     let p2:Point2D = {x:boundingBox.right,y:boundingBox.top};
     let p3:Point2D = {x:boundingBox.right,y:boundingBox.bottom};
     let p4:Point2D = {x:boundingBox.left,y:boundingBox.bottom};
-    cornerPoints.push(p1);
-    cornerPoints.push(p2);
-    cornerPoints.push(p3);
-    cornerPoints.push(p4);
+    const cornerPoints = [p1, p2, p3, p4] as const;
 
     return { 
       boundingBox: boundingBox, 

--- a/src/Definitions.ts
+++ b/src/Definitions.ts
@@ -33,13 +33,13 @@ export interface BarcodeDetectorOptions {
 };
 
 export interface Point2D {
-  x : Number, 
-  y : Number
+  x : number, 
+  y : number
 };
 
 export interface DetectedBarcode {
   boundingBox : DOMRectReadOnly,
   rawValue : String,
   format : BarcodeFormat,
-  cornerPoints : ReadonlyArray<Point2D>
+  cornerPoints: readonly [Point2D, Point2D, Point2D, Point2D]
 };


### PR DESCRIPTION
Hey @xulihang 
Thanks a lot for your work, it has already saved me a lot of time!

In this pull request I have fixed few types for zxing wrapper.
zxing uses exactly `number` primitives, not `Number` instances.

Best regards, 
Pavel
